### PR TITLE
Add VDE switch support

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,22 @@ Others
 
 Other architectures may or may not work.  Adding support is trivial, so ping me if you need another architecture.  Unrecognized architectures use a set of maybe-acceptable defaults.
 
+Virtual Networking
+==================
+
+An outside virtual switch can be created by vde_switch (usually from
+the vde2 package). slirpvde can be used to provide DHCP to the VMs that
+connect to the switch. For instance:
+
+    vde_switch --daemon --sock /tmp/switch1
+    slirpvde --daemon -s /tmp/switch1 --dhcp
+
+Then start the VMs with something like:
+
+    virtme-run --installed-kernel --net --vde-sock=/tmp/switch1 --net-mac=12:45:67:00:00:00
+    virtme-run --installed-kernel --net --vde-sock=/tmp/switch1 --net-mac=12:45:67:00:00:01
+
+
 Upcoming features
 =================
 

--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -56,6 +56,10 @@ def make_parser():
                    help='Show graphical output instead of using a console.')
     g.add_argument('--net', action='store_true',
                    help='Enable basic network access.')
+    g.add_argument('--vde-sock', action='store', default=None,
+                   help='Path to VDE network switch socket')
+    g.add_argument('--net-mac', action='store', default='02:ae:65:32:00:00',
+                   help='MAC adresses base for network adapter')
     g.add_argument('--balloon', action='store_true',
                    help='Allow the host to ask the guest to release memory.')
     g.add_argument('--disk', action='append', default=[], metavar='NAME=PATH',
@@ -357,8 +361,15 @@ def main():
         do_script(shlex.quote(args.script_exec), use_exec=True)
 
     if args.net:
-        qemuargs.extend(['-net', 'nic,model=virtio'])
-        qemuargs.extend(['-net', 'user'])
+        netid = 'net0'
+
+        if args.vde_sock:
+            qemuargs.extend(['-netdev', 'vde,id=' + netid + ',sock=' + args.vde_sock ])
+        else:
+            qemuargs.extend(['-netdev', 'user,id=' + netid])
+
+        qemuargs.extend(['-device', 'virtio-net-pci,netdev=' + netid + ',mac=' + args.net_mac])
+
         kernelargs.extend(['virtme.dhcp'])
 
     if args.pwd:


### PR DESCRIPTION
This allows several VMs to connect to each other.

The --vde-sock option indicates where the VDE switch socket is, and
the --net-mac changes the mac address for a VM.

README updated with an example.

Signed-off-by: Frank Zago <fzago@cray.com>