### PR TITLE
Assorted stuff: Documentation cleanup and module directory parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,12 @@ Once you have such a kernel, run one of:
 * virtme-run --installed-kernel
 * virtme-run --installed-kernel VERSION
 * virtme-run --kimg PATH_TO_KERNEL_IMAGE
+* virtme-run --kimg PATH_TO_KERNEL_IMAGE --mdir PATH_TO_MODULE_DIR
 
-Note that the --kdir and --kimg modes do not support modules yet.
+For instance, let's say you built a v4.15 x86 kernel with modules enabled.
+You would execute this command:
+
+    virtme-run --kimg arch/x86/boot/bzImage --mdir /lib/modules/4.15.0
 
 You can then do things like `cd /home/username` and you will have readonly
 access to all your files.

--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -43,6 +43,8 @@ def make_parser():
     g = parser.add_argument_group(title='Kernel options')
     g.add_argument('-a', '--kopt', action='append', default=[],
                    help='Add a kernel option.  You can specify this more than once.')
+    g.add_argument('--mdir', action='store',
+                   help='Use specified module directory.')
 
     g.add_argument('--xen', action='store',
                    help='Boot Xen using the specified uncompressed hypervisor.')
@@ -144,6 +146,8 @@ def find_kernel_and_mods(arch, args):
     else:
         arg_fail('You must specify a kernel to use.')
 
+    if moddir is None and args.mdir:
+        moddir = args.mdir
     return kimg,dtb,modfiles,moddir
 
 def export_virtfs(qemu, arch, qemuargs, path, mount_tag, security_model='none', readonly=True):


### PR DESCRIPTION
Hey Andy,

`virtme` is the most useful kernel development tool I came across recently: so, thanks!

That said, here's a pull request. It contains a couple things. First, a new parameter to specify a module install path. Then, a small documentation improvement.

UPDATE: https://github.com/amluto/virtme/pull/9 is also trying to specify a modules directory. My version is simpler, but more limited as it won't install modules to a initramfs. The use case is of course using kimg/kdir and wanting to use modules.