### PR TITLE
Transform virtme/guest into a Python package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     license='GPLv2',
     long_description=open(os.path.join(os.path.dirname(__file__),
                                        'README.md'), 'r').read(),
-    packages=['virtme', 'virtme.commands'],
+    packages=['virtme', 'virtme.commands', 'virtme.guest'],
     install_requires=[],
     entry_points = {
         'console_scripts': [
@@ -33,13 +33,9 @@ setup(
             'virtme-configkernel = virtme.commands.configkernel:main',
         ]
     },
-    data_files = [
-        ('share/virtme-guest-0',
-         ['virtme/guest/virtme-init',
-          'virtme/guest/virtme-udhcpc-script',
-          'virtme/guest/virtme-loadmods',
-         ]),
-    ],
+    package_data={
+        'virtme.guest': ['*'],
+    },
     classifiers=['Environment :: Console',
                  'Intended Audience :: Developers',
                  'Intended Audience :: System Administrators',

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,7 @@
 
 import os
 import sys
-
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
+from setuptools import setup
 
 if sys.version_info < (3,3):
     print('virtme requires Python 3.3 or higher')


### PR DESCRIPTION
Related issue: #21 

`setup.py` doesn't copy the necessary bash files from **virtme/guest** folder
to the installed folder. This will make `virtme-run` to fail when running with` --kimg` argument, for example.

This problem can be solved if we transform **virtme/guest** folder, which only have bash
scripts, into a python package via adding a **__init__.py** file and instructing
`setup.py` that _virtme.guest_ is a package and we will need its contents as
package data.

This idea was based on the `setuptools` docs advice:
https://setuptools.readthedocs.io/en/latest/setuptools.html#non-package-data-files

This PR has the related contribution of @ezequielgarcia, which improved the requirements for `setup.py` script.