### PR TITLE
virtme-init: mount cgroup v2

### DIFF
--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -121,6 +121,9 @@ fi
 # Set up useful things in /sys, assuming our kernel supports it.
 mount -t configfs configfs /sys/kernel/config &>/dev/null
 mount -t debugfs debugfs /sys/kernel/debug &>/dev/null
+if grep -q -E '(^| )cgroup_no_v1=all($| )' /proc/cmdline; then
+    mount -t cgroup2 cgroup2 /sys/fs/cgroup &>/dev/null
+fi
 
 # Set up filesystems that live in /dev
 mkdir -p -m 0755 /dev/shm /dev/pts


### PR DESCRIPTION
Automatically mount cgroup v2 filesystem if cgroup_no_v1=all is passed
in the kernel boot options.

Signed-off-by: Andrea Righi <righi.andrea@gmail.com>