### PR TITLE
virtme-init: mount cgroup v2

### DIFF
--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -122,6 +122,11 @@ fi
 mount -t configfs configfs /sys/kernel/config &>/dev/null
 mount -t debugfs debugfs /sys/kernel/debug &>/dev/null
 
+# Set up cgroup mount points (mount cgroupv2 hierarchy by default)
+mount -t tmpfs tmpfs /sys/fs/cgroup &>/dev/null
+mkdir /sys/fs/cgroup/unified
+mount -t cgroup2 cgroup2 /sys/fs/cgroup/unified &>/dev/null
+
 # Set up filesystems that live in /dev
 mkdir -p -m 0755 /dev/shm /dev/pts
 mount -t devpts -o gid=tty,mode=620,noexec,nosuid devpts /dev/pts


### PR DESCRIPTION
Automatically mount cgroup v2 filesystem under /sys/fs/cgroup/unified as
it seems a pretty standard place and tools relying on cgroupv2 are
expecting to find this filesystem mounted there.

Signed-off-by: Andrea Righi <righi.andrea@gmail.com>