### PR TITLE
virtme can now run from a build directory where a make config has been performed.

### DIFF
--- a/virtme/commands/configkernel.py
+++ b/virtme/commands/configkernel.py
@@ -89,9 +89,11 @@ _GENERIC_CONFIG = [
 
 def main():
     args = _ARGPARSER.parse_args()
-
-    if not os.path.isfile('scripts/kconfig/merge_config.sh'):
-        print('virtme-configkernel must be run in a kernel source directory')
+    kernel_source_prefix = "./"
+    if os.path.islink('source'):
+        kernel_source_prefix = 'source/'
+    if not os.path.isfile(kernel_source_prefix + 'scripts/kconfig/merge_config.sh'):
+        print('virtme-configkernel must be run in a kernel source or a kernel build directory')
         return 1
 
     arch = architectures.get(args.arch)


### PR DESCRIPTION
Fixed the issue with 
The kernel_source_prefix not being defined,

