### PR TITLE
virtme-init: create mountpoints if they don't exist

### DIFF
--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -78,7 +78,10 @@ if [[ "`stat --format=%m /dev`" != "/dev" ]]; then
 fi
 
 for tag in "${!virtme_initmount@}"; do
-    mount -t 9p -o version=9p2000.L,trans=virtio,access=any "virtme.initmount${tag:16}" "${!tag}"
+    if [[ ! -d "${!tag}" ]]; then
+        mkdir -p "${!tag}"
+    fi
+    mount -t 9p -o version=9p2000.L,trans=virtio,access=any "virtme.initmount${tag:16}" "${!tag}" || exit 1
 done
 
 if [[ -n "virtme_chdir" ]]; then


### PR DESCRIPTION
Using a shared folder like --rwdir=/run/output=/path/on/host fails,
since the mountpoint under /run does not exist. Create the mountpoint
if it doesn't exist. Also abort the script if mounting fails.