### PR TITLE
virtme-init: use findmnt to detect /dev mount

### DIFF
--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -57,7 +57,7 @@ fi
 mount -t proc -o nosuid,noexec,nodev proc /proc/
 
 # devtmpfs might be automounted; if not, mount it.
-if [[ "`stat --format=%m /dev`" != "/dev" ]]; then
+if ! findmnt --kernel --mountpoint /dev &>/dev/null; then
     # Ideally we'll use devtmpfs (but don't rely on /dev/null existing).
     if [[ -c /dev/null ]]; then
 	mount -n -t devtmpfs -o mode=0755,nosuid,noexec devtmpfs /dev \


### PR DESCRIPTION
In my environment, /dev is available via the 9p root mount, and
therefore virtme-init does not mount a fresh devtmpfs. This means
that udevd later is unable to generate new entries for /dev/vport*.
Using --script-sh or --script-exec therefore fails.

Instead, use findmnt to check whether /dev is automounted by the
current kernel.