### PR TITLE
Using udhcpc default retries

### DIFF
--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -164,7 +164,7 @@ if cat /proc/cmdline |grep -q -E '(^| )virtme.dhcp($| )'; then
 
     # udev is liable to rename the interface out from under us.
     virtme_net=`ls "$(ls -d /sys/bus/virtio/drivers/virtio_net/virtio* |sort -g |head -n1)"/net`
-    busybox udhcpc -i "$virtme_net" -t 1 -n -q -f -s "$(dirname $0)/virtme-udhcpc-script"
+    busybox udhcpc -i "$virtme_net" -n -q -f -s "$(dirname $0)/virtme-udhcpc-script"
 fi
 
 if [[ -x /run/virtme/data/script ]]; then


### PR DESCRIPTION
I've re-used the bridge of libvirtd. A vm gets it lease by the 3rd dhcp requests.

Log of udhcpc without this patch.
udhcpc: sending discover
udhcpc: no lease, failing

Log of udhcpc with this patch.
udhcpc: started, v1.27.2
udhcpc: sending discover
udhcpc: sending discover
udhcpc: sending select for 192.168.123.76
udhcpc: lease of 192.168.123.76 obtained, lease time 3600

This patch removes the '-t' arg to use the default retries which is 3.

Signed-off-by: Jian Wen <wenjianhn@gmail.com>