### PR TITLE
virtme-init: correctly initialize resolv.conf under ubuntu

### DIFF
--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -155,10 +155,18 @@ fi
 ip link set dev lo up
 
 if cat /proc/cmdline |grep -q -E '(^| )virtme.dhcp($| )'; then
-    if [[ -f /etc/resolv.conf ]]; then
+    real_resolv_conf=/etc/resolv.conf
+    if [[ -L "$real_resolv_conf" ]]; then
+        real_resolv_conf="`readlink /etc/resolv.conf`"
+        if [[ ! -e $real_resolv_conf ]]; then
+            mkdir -p "`dirname $real_resolv_conf`"
+            touch $real_resolv_conf
+        fi
+    fi
+    if [[ -f "$real_resolv_conf" ]]; then
 	tmpfile="`mktemp --tmpdir=/tmp`"
 	chmod 644 "$tmpfile"
-	mount --bind "$tmpfile" /etc/resolv.conf
+	mount --bind "$tmpfile" "$real_resolv_conf"
 	rm "$tmpfile"
     fi
 


### PR DESCRIPTION
In recent distro (i.e., Ubuntu) resolv.conf is a symlink to
/run/systemd/resolve/stub-resolv.conf that is not visible by the guest.
This results in a failure when trying to initialize this file.

Make sure to resolve the symlink first and initialize the actual file
with an empty file before trying to rewrite its content.

Signed-off-by: Andrea Righi <andrea.righi@canonical.com>