### PR TITLE
virtme-run: provide a way to support modules with --kdir

### DIFF
--- a/bin/virtme-prep-kdir-mods
+++ b/bin/virtme-prep-kdir-mods
@@ -20,6 +20,7 @@ ln -srfT . "$MODDIR/build"
 # to the build kenrnel.
 find "$MODDIR/kernel" -type l -print0 |xargs -0 rm -f --
 while read -r i; do
+    [ ! -e $i ] && i=$(echo $i | sed s:^kernel/::)
     mkdir -p "$MODDIR/kernel/$(dirname "$i")"
     ln -sr "$i" "$MODDIR/kernel/$i"
 done < modules.order

--- a/bin/virtme-prep-kdir-mods
+++ b/bin/virtme-prep-kdir-mods
@@ -19,10 +19,10 @@ ln -srfT . "$MODDIR/build"
 # Remove all preexisting symlinks and add symlinks to all modules that belong
 # to the build kenrnel.
 find "$MODDIR/kernel" -type l -print0 |xargs -0 rm -f --
-grep -h '.ko$' .tmp_versions/*.mod |while read -r i; do
+while read -r i; do
     mkdir -p "$MODDIR/kernel/$(dirname "$i")"
     ln -sr "$i" "$MODDIR/kernel/$i"
-done
+done < modules.order
 
 
 # Link in the files that make modules_install would copy

--- a/bin/virtme-prep-kdir-mods
+++ b/bin/virtme-prep-kdir-mods
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+# This is still a bit of an experiment.
+
+if ! [ -d .tmp_versions ]; then
+    echo 'virtme-prep-kdir-mods must be run from a kernel build directory' >&2
+    exit 1
+fi
+
+FAKEVER=0.0.0
+MODDIR=".virtme_mods/lib/modules/$FAKEVER"
+
+# Set up .virtme_mods/lib/modules/0.0.0 as a module directory for this kernel,
+# but fill it with symlinks instead of actual modules.
+
+mkdir -p "$MODDIR/kernel"
+ln -srfT . "$MODDIR/build"
+
+# Remove all preexisting symlinks and add symlinks to all modules that belong
+# to the build kenrnel.
+find "$MODDIR/kernel" -type l -print0 |xargs -0 rm -f --
+grep -h '.ko$' .tmp_versions/*.mod |while read -r i; do
+    mkdir -p "$MODDIR/kernel/$(dirname "$i")"
+    ln -sr "$i" "$MODDIR/kernel/$i"
+done
+
+
+# Link in the files that make modules_install would copy
+ln -srf modules.builtin modules.builtin.modinfo modules.order "$MODDIR/"
+
+# Now run depmod to collect dependencies
+depmod -ae -F System.map -b .virtme_mods "$FAKEVER"

--- a/bin/virtme-prep-kdir-mods
+++ b/bin/virtme-prep-kdir-mods
@@ -10,6 +10,11 @@ fi
 FAKEVER=0.0.0
 MODDIR=".virtme_mods/lib/modules/$FAKEVER"
 
+if ! [ -f "modules.order" ]; then
+    echo "modules.order is missing.  Your kernel may be too old or you didn't make modules." >&2
+    exit 1
+fi
+
 # Set up .virtme_mods/lib/modules/0.0.0 as a module directory for this kernel,
 # but fill it with symlinks instead of actual modules.
 
@@ -20,7 +25,7 @@ ln -srfT . "$MODDIR/build"
 # to the build kenrnel.
 find "$MODDIR/kernel" -type l -print0 |xargs -0 rm -f --
 while read -r i; do
-    [ ! -e $i ] && i=$(echo $i | sed s:^kernel/::)
+    [ ! -e "$i" ] && i=$(echo "$i" | sed s:^kernel/::)
     mkdir -p "$MODDIR/kernel/$(dirname "$i")"
     ln -sr "$i" "$MODDIR/kernel/$i"
 done < modules.order

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,9 @@ setup(
             'virtme-configkernel = virtme.commands.configkernel:main',
         ]
     },
+    scripts = [
+        'bin/virtme-prep-kdir-mods',
+        ],
     package_data = {
         'virtme.guest': [
             'virtme-init',

--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -134,11 +134,19 @@ def find_kernel_and_mods(arch, args):
     elif args.kdir is not None:
         kimg = os.path.join(args.kdir, arch.kimg_path())
         virtme_mods = os.path.join(args.kdir, '.virtme_mods')
-        if os.path.exists(virtme_mods):
+        mod_file = os.path.join(args.kdir, 'modules.order')
+        try:
+            if not os.path.exists(mod_file):
+                raise Exception('%s not found' % mod_file)
+            # Initialize virtme modules directory
+            if not os.path.exists(virtme_mods):
+                os.system('virtme-prep-kdir-mods')
+            if not os.path.exists(virtme_mods):
+                raise Exception('%s not found' % virtme_mods)
             moddir = os.path.join(virtme_mods, 'lib/modules', '0.0.0')
             modfiles = modfinder.find_modules_from_install(
                 virtmods.MODALIASES, kver='0.0.0')
-        else:
+        except:
             kver = None
             moddir = None
             modfiles = []

--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -118,6 +118,9 @@ def arg_fail(message):
     _ARGPARSER.print_usage()
     sys.exit(1)
 
+def is_file_more_recent(a, b):
+    return os.stat(a).st_mtime > os.stat(b).st_mtime
+
 def find_kernel_and_mods(arch, args):
     use_root_mods = False
 
@@ -135,11 +138,13 @@ def find_kernel_and_mods(arch, args):
         kimg = os.path.join(args.kdir, arch.kimg_path())
         virtme_mods = os.path.join(args.kdir, '.virtme_mods')
         mod_file = os.path.join(args.kdir, 'modules.order')
+        virtme_mod_file = os.path.join(virtme_mods, 'lib/modules/0.0.0/modules.dep')
         try:
             if not os.path.exists(mod_file):
                 raise Exception('%s not found' % mod_file)
             # Initialize virtme modules directory
-            if not os.path.exists(virtme_mods):
+            if not os.path.exists(virtme_mods) or \
+               is_file_more_recent(mod_file, virtme_mod_file):
                 os.system('virtme-prep-kdir-mods')
             if not os.path.exists(virtme_mods):
                 raise Exception('%s not found' % virtme_mods)

--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -27,10 +27,12 @@ done
 
 kver="`uname -r`"
 
-if [[ -n "${mount_tags[virtme.moddir]}" ]]; then
-    mount -t tmpfs none /lib/modules
-    mkdir /lib/modules/"$kver"
-    mount -n -t 9p -o ro,version=9p2000.L,trans=virtio,access=any virtme.moddir /lib/modules/"$kver"
+if [[ -n "$virtme_root_mods" ]]; then
+    # /lib/modules is already set up
+    true
+elif [[ -n "$virtme_link_mods" ]]; then
+    mount -n -t tmpfs none /lib/modules
+    ln -s "$virtme_link_mods" "/lib/modules/$kver"
 elif [[ -d "/lib/modules/$kver" ]]; then
     # We may have mismatched modules.  Mask them off.
     mount -n -t tmpfs -o ro,mode=0000 disallow_modules "/lib/modules/$kver"

--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -155,10 +155,18 @@ fi
 ip link set dev lo up
 
 if cat /proc/cmdline |grep -q -E '(^| )virtme.dhcp($| )'; then
-    if [[ -f /etc/resolv.conf ]]; then
+    real_resolv_conf=/etc/resolv.conf
+    if [[ -L "$real_resolv_conf" ]]; then
+        real_resolv_conf="`readlink /etc/resolv.conf`"
+        if [[ ! -e $real_resolv_conf ]]; then
+            mkdir -p "`dirname $real_resolv_conf`"
+            touch $real_resolv_conf
+        fi
+    fi
+    if [[ -f "$real_resolv_conf" ]]; then
 	tmpfile="`mktemp --tmpdir=/tmp`"
 	chmod 644 "$tmpfile"
-	mount --bind "$tmpfile" /etc/resolv.conf
+	mount --bind "$tmpfile" "$real_resolv_conf"
 	rm "$tmpfile"
     fi
 

--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -172,7 +172,7 @@ if cat /proc/cmdline |grep -q -E '(^| )virtme.dhcp($| )'; then
 
     # udev is liable to rename the interface out from under us.
     virtme_net=`ls "$(ls -d /sys/bus/virtio/drivers/virtio_net/virtio* |sort -g |head -n1)"/net`
-    busybox udhcpc -i "$virtme_net" -t 1 -n -q -f -s "$(dirname $0)/virtme-udhcpc-script"
+    busybox udhcpc -i "$virtme_net" -n -q -f -s "$(dirname $0)/virtme-udhcpc-script"
 fi
 
 if [[ -x /run/virtme/data/script ]]; then

--- a/virtme/modfinder.py
+++ b/virtme/modfinder.py
@@ -12,6 +12,7 @@ everything.  The idea is to require very few modules.
 """
 
 import re
+import shutil
 import subprocess
 import os, os.path
 import itertools
@@ -19,7 +20,9 @@ import itertools
 _INSMOD_RE = re.compile('insmod (.*[^ ]) *$')
 
 def resolve_dep(modalias, root=None, kver=None, moddir=None):
-    args = ['modprobe', '--show-depends']
+    # /usr/sbin might not be in the path, and modprobe is usually in /usr/sbin
+    modprobe = shutil.which('modprobe') or '/usr/sbin/modprobe'
+    args = [modprobe, '--show-depends']
     args += ['-C', '/var/empty']
     if root is not None:
         args += ['-d', root]


### PR DESCRIPTION
When --kdir is provided there's not an easy and automated way to use
kernel modules from the guest.

A possible solution could be to install all the modules inside the
kernel build directory (argument of --kdir) inside a temporary directory
.tmp_moddir/ as following:

 $ make modules_install INSTALL_MOD_DIR=.tmp_moddir

In this way if .tmp_moddir is found the guest can use the kernel modules
from this directory, otherwise fallback to the old behavior and do not
provide an automated way to access the kernel modules.

TODO: document this .tmp_moddir/ directory somewhere.

Signed-off-by: Andrea Righi <andrea.righi@canonical.com>