### PR TITLE
Make virtme-mkinitramfs great again

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         'console_scripts': [
             'virtme-run = virtme.commands.run:main',
             'virtme-configkernel = virtme.commands.configkernel:main',
+            'virtme-mkinitramfs = virtme.commands.mkinitramfs:main',
         ]
     },
     package_data = {

--- a/virtme-mkinitramfs
+++ b/virtme-mkinitramfs
@@ -1,0 +1,15 @@
+#!/usr/bin/python3
+# -*- mode: python -*-
+# virtme-mkinitramfs: Generate an initramfs image for virtme
+# Copyright © 2014 Andy Lutomirski
+# Licensed under the GPLv2, which is available in the virtme distribution
+# as a file called LICENSE with SHA-256 hash:
+# 8177f97513213526df2cf6184d8ff986c675afb514d4e68a404010521b880643
+
+import sys
+if sys.version_info < (3,3):
+    print('virtme requires Python 3.3 or higher')
+    sys.exit(1)
+
+from virtme.commands import mkinitramfs
+exit(mkinitramfs.main())

--- a/virtme/commands/mkinitramfs.py
+++ b/virtme/commands/mkinitramfs.py
@@ -27,6 +27,9 @@ def main():
         config.modfiles = modfinder.find_modules_from_install(
             virtmods.MODALIASES, kver=args.mod_kversion)
 
+    # search for busybox in the root filesystem
+    config.busybox = mkinitramfs.find_busybox(root = '/', is_native = True)
+
     if args.rw:
         config.access = 'rw'
 

--- a/virtme/commands/mkinitramfs.py
+++ b/virtme/commands/mkinitramfs.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python3
 # -*- mode: python -*-
 # virtme-mkinitramfs: Generate an initramfs image for virtme
 # Copyright © 2014 Andy Lutomirski

--- a/virtme/commands/mkinitramfs.py
+++ b/virtme/commands/mkinitramfs.py
@@ -10,16 +10,23 @@ from .. import modfinder
 from .. import virtmods
 from .. import mkinitramfs
 
-_ARGPARSER = argparse.ArgumentParser(
-    description='Generate initramfs image for virtme',
-)
-_ARGPARSER.add_argument('--mod-kversion', action='store', default=None)
-_ARGPARSER.add_argument('--rw', action='store_true', default=False)
+def make_parser():
+    parser = argparse.ArgumentParser(
+        description='Generate an initramfs image for virtme',
+    )
+
+    parser.add_argument('--mod-kversion', action='store', default=None,
+                        help='Find kernel modules related to kernel version set')
+
+    parser.add_argument('--rw', action='store_true', default=False,
+                        help='Mount initramfs as rw. Default is ro')
+
+    return parser
 
 def main():
     import sys
 
-    args = _ARGPARSER.parse_args()
+    args = make_parser().parse_args()
 
     config = mkinitramfs.Config()
 

--- a/virtme/commands/mkinitramfs.py
+++ b/virtme/commands/mkinitramfs.py
@@ -21,6 +21,9 @@ def make_parser():
     parser.add_argument('--rw', action='store_true', default=False,
                         help='Mount initramfs as rw. Default is ro')
 
+    parser.add_argument('--outfile', action='store', default=None,
+                        help='Filename of the resulting initramfs file. Default: send initramfs to stdout')
+
     return parser
 
 def main():
@@ -40,7 +43,12 @@ def main():
     if args.rw:
         config.access = 'rw'
 
-    mkinitramfs.mkinitramfs(sys.stdout.buffer, config)
+    if args.outfile is None:
+        buf = sys.stdout.buffer
+    else:
+        buf = open(args.outfile, 'w+b')
+
+    mkinitramfs.mkinitramfs(buf, config)
 
     return 0
 

--- a/virtme/commands/mkinitramfs.py
+++ b/virtme/commands/mkinitramfs.py
@@ -6,9 +6,9 @@
 # 8177f97513213526df2cf6184d8ff986c675afb514d4e68a404010521b880643
 
 import argparse
-import modfinder
-import virtmods
-import mkinitramfs
+from .. import modfinder
+from .. import virtmods
+from .. import mkinitramfs
 
 _ARGPARSER = argparse.ArgumentParser(
     description='Generate initramfs image for virtme',


### PR DESCRIPTION
While trying to create an initrd file using virtme-mkinitramfs, I found this script is not currently working, and is neither being installed like virtme-run and virtme-configkernel.

Let me know if I misunderstood the purpose of the tool or if the code needs some polishment.