### PR TITLE
More potential paths for busybox executable

### DIFF
--- a/virtme/mkinitramfs.py
+++ b/virtme/mkinitramfs.py
@@ -168,7 +168,7 @@ def mkinitramfs(out, config):
 def find_busybox(root, is_native):
     for p in itertools.product(['usr/local', 'usr', ''],
                                ['bin', 'sbin'],
-                               ['', '-static']):
+                               ['', '-static', '.static']):
         path = os.path.join(root, p[0], p[1], 'busybox' + p[2])
         if os.path.isfile(path):
             return path

--- a/virtme/mkinitramfs.py
+++ b/virtme/mkinitramfs.py
@@ -9,6 +9,7 @@ import shutil
 import io
 import os.path
 import shlex
+import itertools
 from . import cpiowriter
 from . import modfinder
 from . import virtmods
@@ -165,12 +166,12 @@ def mkinitramfs(out, config):
     cw.write_trailer()
 
 def find_busybox(root, is_native):
-    for path in ('usr/local/bin/busybox', 'usr/local/sbin/busybox',
-                 'usr/bin/busybox-static',
-                 'usr/bin/busybox', 'usr/sbin/busybox',
-                 'bin/busybox', 'sbin/busybox'):
-        if os.path.isfile(os.path.join(root, path)):
-            return os.path.join(root, path)
+    for p in itertools.product(['usr/local', 'usr', ''],
+                               ['bin', 'sbin'],
+                               ['', '-static']):
+        path = os.path.join(root, p[0], p[1], 'busybox' + p[2])
+        if os.path.isfile(path):
+            return path
 
     if is_native:
         # Try the host's busybox, if any


### PR DESCRIPTION
This is on a somewhat related note to https://github.com/amluto/virtme/pull/13 in aiming to broaden the range of busybox packaging styles virtme can support.

Void Linux offers both statically and dynamically linked versions of busybox in its package repos.  Without #13, virtme requires a static build, but unfortunately for virtme Void's busybox-static package installs a binary called `busybox.static` (as opposed to the `busybox-static` virtme currently searches for).

So either #13 or this would address the immediate "virtme doesn't work on my distro" problem, though I think there could still potentially be value in both (would support either version of the package instead of requiring the static one).