### PR TITLE
commands/configkernel.py: Check KBUILD_OUTPUT environment variable

### DIFF
--- a/virtme/commands/configkernel.py
+++ b/virtme/commands/configkernel.py
@@ -121,7 +121,14 @@ def main():
     if maketarget:
         subprocess.check_call(['make', 'ARCH=%s' % arch.linuxname, maketarget])
 
-    with open('.config', 'ab') as conffile:
+    config = '.config'
+
+    # Check if KBUILD_OUTPUT is defined and if it's a directory
+    config_dir = os.environ.get('KBUILD_OUTPUT', '')
+    if config_dir and os.path.isdir(config_dir):
+        config = os.path.join(config_dir, config)
+
+    with open(config, 'ab') as conffile:
         conffile.write('\n'.join(conf).encode('utf-8'))
 
     subprocess.check_call(['make', 'ARCH=%s' % arch.linuxname, updatetarget])


### PR DESCRIPTION
If KBUILD_OUTPUT is defined, and if it's a directory, write the .config file in location defined.

Fixes: #24 

Signed-off-by: Marcos Paulo de Souza <marcos.souza.org@gmail.com>