### PR TITLE
virtme: modfinder: Try to find modprobe in /sbin/ too

### DIFF
--- a/virtme/modfinder.py
+++ b/virtme/modfinder.py
@@ -22,8 +22,10 @@ import itertools
 _INSMOD_RE = re.compile('insmod (.*[^ ]) *$')
 
 def resolve_dep(modalias, root=None, kver=None, moddir=None):
-    # /usr/sbin might not be in the path, and modprobe is usually in /usr/sbin
-    modprobe = shutil.which('modprobe') or '/usr/sbin/modprobe'
+    # both /usr/sbin or /sbin might not be in the path, so check them both.
+    # modprobe is usually in in /usr/sbin
+    modprobe = shutil.which('modprobe') or shutil.which('/usr/sbin/modprobe') \
+                or '/sbin/modprobe'
     args = [modprobe, '--show-depends']
     args += ['-C', '/var/empty']
     if root is not None:


### PR DESCRIPTION
Debian 10 has modprobe in /sbin/, so adjust resolve_dep to check for
this place too.

Tested-by: Gabriela Bittencourt <gabrielabittencourt00@gmail.com>
Signed-off-by: Marcos Paulo de Souza <mpdesouza@suse.com>