### PR TITLE
remove duplicated check from virtme-prep-kdir-mods

### DIFF
--- a/bin/virtme-prep-kdir-mods
+++ b/bin/virtme-prep-kdir-mods
@@ -1,12 +1,6 @@
 #!/bin/sh
 
 # This is still a bit of an experiment.
-
-if ! [ -f modules.order ]; then
-    echo 'virtme-prep-kdir-mods must be run from a kernel build directory' >&2
-    exit 1
-fi
-
 FAKEVER=0.0.0
 MODDIR=".virtme_mods/lib/modules/$FAKEVER"
 
@@ -16,6 +10,7 @@ MODDIR=".virtme_mods/lib/modules/$FAKEVER"
 PATH=$PATH:/sbin:/usr/sbin
 
 if ! [ -f "modules.order" ]; then
+    echo 'virtme-prep-kdir-mods must be run from a kernel build directory' >&2
     echo "modules.order is missing.  Your kernel may be too old or you didn't make modules." >&2
     exit 1
 fi


### PR DESCRIPTION
Existence of modules.order is checked twice.

Signed-off-by: Pavel Tatashin <pasha.tatashin@soleen.com>