### PR TITLE
s390x: avoid to set serial console

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -352,12 +352,14 @@ def do_it() -> int:
         # in current kernels.  Nonetheless, I'm configuring the console
         # manually to make it easier to tweak in the future.
         qemuargs.extend(['-echr', '1'])
-        qemuargs.extend(['-serial', 'none'])
+        if arch.qemuname != 's390x':
+            qemuargs.extend(['-serial', 'none'])
         qemuargs.extend(['-chardev', 'stdio,id=console,signal=off,mux=on'])
 
         # We should be using the new-style -device serialdev,chardev=xyz,
         # but many architecture-specific serial devices don't support that.
-        qemuargs.extend(['-serial', 'chardev:console'])
+        if arch.qemuname != 's390x':
+            qemuargs.extend(['-serial', 'chardev:console'])
 
         qemuargs.extend(['-mon', 'chardev=console'])
 
@@ -423,12 +425,14 @@ def do_it() -> int:
         qemuargs.extend(arch.qemu_nodisplay_args())
 
         # Send kernel logs to stderr
-        qemuargs.extend(['-serial', 'none'])
+        if arch.qemuname != 's390x':
+            qemuargs.extend(['-serial', 'none'])
         qemuargs.extend(['-chardev', 'file,id=console,path=/proc/self/fd/2'])
 
         # We should be using the new-style -device serialdev,chardev=xyz,
         # but many architecture-specific serial devices don't support that.
-        qemuargs.extend(['-serial', 'chardev:console'])
+        if arch.qemuname != 's390x':
+            qemuargs.extend(['-serial', 'chardev:console'])
 
         if show_boot_console:
             serdev = qemu.quote_optarg(arch.serial_dev_name(0))


### PR DESCRIPTION
The serial console and the sclpconsole conflict with this error on s390x:
qemu-system-s390x: -device sclpconsole,chardev=console: Multiple VT220 operator consoles are not supported
qemu-system-s390x: -device sclpconsole,chardev=console: SCLP event initialization failed.

We can only enable the sclpconsole console

Signed-off-by: Alice Frosi <afrosi@de.ibm.com>