### PR TITLE
Make scripts PATH friendly for searching python3

### DIFF
--- a/virtme-configkernel
+++ b/virtme-configkernel
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- mode: python -*-
 # virtme-configkernel: Configure a kernel for virtme
 # Copyright © 2014 Andy Lutomirski

--- a/virtme-mkinitramfs
+++ b/virtme-mkinitramfs
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- mode: python -*-
 # virtme-mkinitramfs: Generate an initramfs image for virtme
 # Copyright © 2019 Marcos Paulo de Souza

--- a/virtme-run
+++ b/virtme-run
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- mode: python -*-
 # virtme-run: The main command-line virtme frontend
 # Copyright © 2014 Andy Lutomirski


### PR DESCRIPTION
This is helpful when system version of python3 is too old for running new syntax used in the virtme scripts. And newer version of python3 can be compiled and installed in user local directory.