### PR TITLE
virtme-configkernel: Fix --allnoconfig option

### DIFF
--- a/virtme/commands/configkernel.py
+++ b/virtme/commands/configkernel.py
@@ -113,7 +113,7 @@ def main():
 
     if args.allnoconfig:
         maketarget = 'allnoconfig'
-        updatetarget = 'silentoldconfig'
+        updatetarget = 'syncconfig'
     elif args.defconfig:
         maketarget = arch.defconfig_target
         updatetarget = 'olddefconfig'


### PR DESCRIPTION
Kernel commit 911a91c39cab ("kconfig: rename silentoldconfig to
syncconfig"), so also rename the updatetarget in virtme to reflect the
change.

Signed-off-by: Marcos Paulo de Souza <mpdesouza@suse.com>