### PR TITLE
virtme-init: generate dummy /etc/shadow

### DIFF
--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -46,6 +46,13 @@ touch /tmp/fstab
 mount --bind /tmp/fstab /etc/fstab
 rm /tmp/fstab
 
+# Populate dummy entries in /etc/shadow to allow switching to any user defined
+# in the system
+touch /tmp/shadow
+chmod 0640 /tmp/shadow
+sed -e 's/^\([^:]\+\).*/\1:x:::::::/' < /etc/passwd > /tmp/shadow
+mount --bind /tmp/shadow /etc/shadow
+
 # Find udevd
 if [[ -x /usr/lib/systemd/systemd-udevd ]]; then
     udevd=/usr/lib/systemd/systemd-udevd


### PR DESCRIPTION
Trying to switch to any non-root user from a virtme environment returns
the following error:

 su: Authentication failure

Populate dummy entries in /etc/shadow to allow switching to any user
defined in the system.

Signed-off-by: Andrea Righi <andrea.righi@canonical.com>