### PR TITLE
virtme-prep-kdir-mods: Add --copy-modules argument

### DIFF
--- a/bin/virtme-prep-kdir-mods
+++ b/bin/virtme-prep-kdir-mods
@@ -9,6 +9,32 @@ MODDIR=".virtme_mods/lib/modules/$FAKEVER"
 # (depmod, etc.).
 PATH=$PATH:/sbin:/usr/sbin
 
+COPY_MODULES=${COPY_MODULES:-"false"}
+
+function print_help {
+    script_name=$(basename "$0")
+    echo "usage: ${script_name} [-h | --help] [-c | --copy-modules]"
+    echo ""
+    echo "optional arguments:"
+    echo "  -h, --help          show this help message and exit"
+    echo "  -c, --copy-modules  copy kernel instead of linking"
+}
+
+while ":"; do
+    case "$1" in
+	-h | --help)
+	    print_help
+	    exit 0
+	    ;;
+	-c | --copy-modules)
+	    COPY_MODULES="true"
+	    shift
+	    ;;
+	*)
+	    break
+    esac
+done
+
 if ! [ -f "modules.order" ]; then
     echo 'virtme-prep-kdir-mods must be run from a kernel build directory' >&2
     echo "modules.order is missing.  Your kernel may be too old or you didn't make modules." >&2
@@ -27,7 +53,11 @@ find "$MODDIR/kernel" -type l -print0 |xargs -0 rm -f --
 while read -r i; do
     [ ! -e "$i" ] && i=$(echo "$i" | sed s:^kernel/::)
     mkdir -p "$MODDIR/kernel/$(dirname "$i")"
-    ln -sr "$i" "$MODDIR/kernel/$i"
+    if [[ "$COPY_MODULES" == "true" ]]; then
+	cp "$i" "$MODDIR/kernel/$i"
+    else
+	ln -sr "$i" "$MODDIR/kernel/$i"
+    fi
 done < modules.order
 
 


### PR DESCRIPTION
Symbolic linking of kernel modules to .virtme_mods/... is problematic
when running xfstests. Some of them are copying modules to SCRATCH disks
without following links[0]. This change allows for optional copying
of modules to avoid xfstests failures with the new --copy-modules
argument.

[0] https://git.kernel.org/pub/scm/fs/xfs/xfstests-dev.git/tree/tests/btrfs/012?id=37d4f926b525fbba8aa579b9eea4ae0921ea7b7b#n55

Signed-off-by: Michal Rostecki <mrostecki@suse.de>