### PR TITLE
run: Add a --script-dir to run user-defined init-scripts

### DIFF
--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -233,6 +233,12 @@ echo "virtme-init: console is $consdev"
 install -d -m 0755 /tmp/roothome
 export HOME=/tmp/roothome
 
+if [[ -d /run/virtme/user ]]; then
+    for s in /run/virtme/user/*.sh; do
+        setsid $s 0<>"/dev/$consdev" 1>&0 2>&0
+    done
+fi
+
 # Bring up a functioning shell on the console.  This is a bit magical:
 # We have no controlling terminal because we're attached to a fake
 # console device (probably something like /dev/console), which can't


### PR DESCRIPTION
```
This new parameter can be used as:

  virtme-run --kdir ~/repos/builds/virtme-x86_64 --script-dir test/

And virtme will run any *.sh script in ./test dir in the guest.

Signed-off-by: Ezequiel Garcia <ezequiel@collabora.com>
```

I'd like to upstream this patch from @ezequielgarcia (https://github.com/ezequielgarcia/virtme/commit/c7760c75104e7db48734a62d5f519f4a00aa0dfb). I'm aware of `--script-sh`, but it only allows a single command, and, more importantly, it cannot be used together with `--graphics`. So, for the use case of automatically running tests on a graphical environment, `--script-dir` is a must.

Signed-off-by: Nícolas F. R. A. Prado <nfraprado@collabora.com>