### PR TITLE
run.py: fix qemu short-form boolean warning

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -248,7 +248,7 @@ def export_virtfs(qemu: qemu_helpers.Qemu, arch: architectures.Arch,
     fsid = 'virtfs%d' % len(qemuargs)
     qemuargs.extend(['-fsdev', 'local,id=%s,path=%s,security_model=%s%s%s' %
                      (fsid, qemu.quote_optarg(path),
-                      security_model, ',readonly' if readonly else '',
+                      security_model, ',readonly=on' if readonly else '',
                       ',multidevs=remap' if qemu.has_multidevs else '')])
     qemuargs.extend(['-device', '%s,fsdev=%s,mount_tag=%s' % (arch.virtio_dev_type('9p'), fsid, qemu.quote_optarg(mount_tag))])
 


### PR DESCRIPTION
When running virtme with qemu 6.0.0 it complains about the deprecation of
short options:

qemu-system-x86_64: -fsdev local,id=virtfs1,path=/,security_model=none,readonly,multidevs=remap: warning: short-form boolean option 'readonly' deprecated
Please use readonly=on instead
qemu-system-x86_64: -fsdev local,id=virtfs5,path=/usr/lib/python3.8/site-packages/virtme-0.1.1-py3.8.egg/virtme/guest,security_model=none,readonly,multidevs=remap: warning: short-form boolean option 'readonly' deprecated
Please use readonly=on instead

Just pass in 'readonly=on' to silence the warning again.

Signed-off-by: Johannes Thumshirn <johannes.thumshirn@wdc.com>