### PR TITLE
run.py: Add --overlay-rwdir flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ For script support, you need CONFIG_VIRTIO_CONSOLE.
 
 For disk support, you need CONFIG_SCSI_VIRTIO.
 
+For --overlay-rwdir support, you need CONFIG_OVERLAY_FS.
+
 That kernel needs to be sane.  Your kernel is probably sane, but allmodconfig and allyesconfig generate insane kernels.  Sanity includes:
 
     CONFIG_CMDLINE_OVERRIDE=n

--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -86,6 +86,16 @@ if ! findmnt --kernel --mountpoint /dev &>/dev/null; then
     fi
 fi
 
+for tag in "${!virtme_rw_overlay@}"; do
+    td=`mktemp -d`
+    dir="${!tag}"
+    mount -t tmpfs none "$td"
+    mkdir "$td/cow" "$td/work"
+    mount -t overlay -o "lowerdir=$dir,upperdir=$td/cow,workdir=$td/work" cow "$dir"
+    umount "$td"
+    rmdir "$td"
+done
+
 for tag in "${!virtme_initmount@}"; do
     if [[ ! -d "${!tag}" ]]; then
         mkdir -p "${!tag}"


### PR DESCRIPTION
This allows the guest to have non-destructive (simulated) write access
to parts of the host filesystem.

Signed-off-by: Zev Weiss <zev@bewilderbeest.net>