### PR TITLE
s390x: Override serial console arguments for qemu

### DIFF
--- a/virtme/architectures.py
+++ b/virtme/architectures.py
@@ -44,6 +44,12 @@ class Arch(object):
         return ['-vga', 'none', '-display', 'none']
 
     @staticmethod
+    def qemu_serial_console_args() -> List[str]:
+        # We should be using the new-style -device serialdev,chardev=xyz,
+        # but many architecture-specific serial devices don't support that.
+        return ['-serial', 'chardev:console']
+
+    @staticmethod
     def config_base() -> List[str]:
         return []
 
@@ -281,13 +287,15 @@ class Arch_s390x(Arch):
         # default console
         ret.extend(['-nodefaults'])
 
-        ret.extend(['-device', 'sclpconsole,chardev=console'])
-
         return ret
 
     @staticmethod
     def config_base():
         return ['CONFIG_MARCH_Z900=y']
+
+    @staticmethod
+    def qemu_serial_console_args():
+        return ['-device', 'sclpconsole,chardev=console']
 
 ARCHES = {arch.virtmename: arch for arch in [
     Arch_x86('x86_64'),

--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -376,9 +376,7 @@ def do_it() -> int:
         qemuargs.extend(['-serial', 'none'])
         qemuargs.extend(['-chardev', 'stdio,id=console,signal=off,mux=on'])
 
-        # We should be using the new-style -device serialdev,chardev=xyz,
-        # but many architecture-specific serial devices don't support that.
-        qemuargs.extend(['-serial', 'chardev:console'])
+        qemuargs.extend(arch.qemu_serial_console_args())
 
         qemuargs.extend(['-mon', 'chardev=console'])
 


### PR DESCRIPTION
As Alice Frosi reported (PR #58), passing

    -device sclpconsole,chardev=console

together with

    -serial chardev:console

to qemu-system-s390x is not supported.

Following Andrew Lutomirski's suggestion, use the latter as the default for
configuring the serial console on all architectures but s390x, where we
override it in favor of sclpconsole.

Signed-off-by: Jakub Sitnicki <jakub@cloudflare.com>