### PR TITLE
virtme/architectures.py: Fix ppc64le support

### DIFF
--- a/virtme/architectures.py
+++ b/virtme/architectures.py
@@ -194,9 +194,9 @@ class Arch_aarch64(Arch):
     def kimg_path(self):
         return 'arch/arm64/boot/Image'
 
-class Arch_ppc64(Arch):
-    def __init__(self):
-        Arch.__init__(self, 'ppc64')
+class Arch_ppc(Arch):
+    def __init__(self, name):
+        Arch.__init__(self, name)
 
         self.defconfig_target = 'ppc64_defconfig'
         self.qemuname = 'ppc64'
@@ -294,7 +294,8 @@ ARCHES = {arch.virtmename: arch for arch in [
     Arch_x86('i386'),
     Arch_arm(),
     Arch_aarch64(),
-    Arch_ppc64(),
+    Arch_ppc('ppc64'),
+    Arch_ppc('ppc64le'),
     Arch_riscv64(),
     Arch_sparc64(),
     Arch_s390x(),


### PR DESCRIPTION
Fix virtme usage on ppc64le. virtme-run tries to match the uname.machine
with all supported architectures and returns an Arch object. There
isn't a 'ppc64le' version, so it ends up in the Arch_unknown('ppc64le'),
which later on is used to find the qemu-system-$arch command.

There isn't a qemu-system-ppc64le, only qemu-system-{ppc,ppc64}.
Replicating the configuration for ppc64 and ppc64le fixes the problem.

Signed-off-by: Marcos Paulo de Souza <mpdesouza@suse.com>