### PR TITLE
virtme-configkernel: introduce option --custom FILE

### DIFF
--- a/virtme/commands/configkernel.py
+++ b/virtme/commands/configkernel.py
@@ -26,6 +26,9 @@ def make_parser():
                         default=uname.machine,
                         help='Target architecture')
 
+    parser.add_argument('--custom', action='store', metavar='CUSTOM',
+                        help='Use a custom config snippet file to override specific config options')
+
     g = parser.add_argument_group(title='Mode').add_mutually_exclusive_group()
 
     g.add_argument('--allnoconfig', action='store_true',
@@ -100,9 +103,15 @@ def main():
 
     arch = architectures.get(args.arch)
 
+    custom_conf = []
+    if args.custom:
+        with open(args.custom) as fd:
+            custom_conf = list(fd.readlines())
+
     conf = (_GENERIC_CONFIG +
             ['# Arch-specific options'] +
-            arch.config_base())
+            arch.config_base() +
+            custom_conf)
 
     archargs = ['ARCH=%s' % shlex.quote(arch.linuxname)]
 


### PR DESCRIPTION
Introduce an option to specify a custom .config snippet file to override the default settings used by virtme-configkernel.

Signed-off-by: Andrea Righi <andrea.righi@canonical.com>