### PR TITLE
virtme-run: properly forward stdin with --script-sh

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -466,9 +466,13 @@ def do_it() -> int:
                                'earlyprintk=serial,%s,115200' % serdev])
 
         # Set up a virtserialport for script I/O
-        qemuargs.extend(['-chardev', 'stdio,id=stdio,signal=on,mux=off'])
+        qemuargs.extend(['-chardev', 'stdio,id=stdin,signal=on,mux=off'])
         qemuargs.extend(['-device', arch.virtio_dev_type('serial')])
-        qemuargs.extend(['-device', 'virtserialport,name=virtme.scriptio,chardev=stdio'])
+        qemuargs.extend(['-device', 'virtserialport,name=virtme.stdin,chardev=stdin'])
+
+        qemuargs.extend(['-chardev', 'file,id=stdout,path=/proc/self/fd/1'])
+        qemuargs.extend(['-device', arch.virtio_dev_type('serial')])
+        qemuargs.extend(['-device', 'virtserialport,name=virtme.stdout,chardev=stdout'])
 
         # Scripts shouldn't reboot
         qemuargs.extend(['-no-reboot'])

--- a/virtme/guest/virtme-init
+++ b/virtme/guest/virtme-init
@@ -185,14 +185,14 @@ if cat /proc/cmdline |grep -q -E '(^| )virtme.dhcp($| )'; then
 fi
 
 if [[ -x /run/virtme/data/script ]]; then
-    if [[ ! -e "/dev/virtio-ports/virtme.scriptio" ]]; then
-	echo "virtme-init: cannot find script I/O port; make sure virtio-serial is available"
+    if [[ ! -e "/dev/virtio-ports/virtme.stdin" || ! -e "/dev/virtio-ports/virtme.stdout" ]]; then
+	echo "virtme-init: cannot find script I/O ports; make sure virtio-serial is available"
 	poweroff -f
 	exit 1
     fi
 
     log 'starting script'
-    setsid /run/virtme/data/script <>/dev/virtio-ports/virtme.scriptio 1>&0 2>&0
+    setsid /run/virtme/data/script </dev/virtio-ports/virtme.stdin >/dev/virtio-ports/virtme.stdout 2>&1
     log "script returned $?"
 
     # Hmm.  We should expose the return value somehow.


### PR DESCRIPTION
Properly forward stdin to script executed in the guest with --script-sh by creating two separate virtio ports for stdin and stdout. Then the script will read from the stdin port and write to the stdout port.

Signed-off-by: Andrea Righi <andrea.righi@canonical.com>