### PR TITLE
s/-watchdog/-device

### DIFF
--- a/virtme/architectures.py
+++ b/virtme/architectures.py
@@ -71,7 +71,7 @@ class Arch_x86(Arch):
         ret = Arch.qemuargs(is_native)
 
         # Add a watchdog.  This is useful for testing.
-        ret.extend(['-watchdog', 'i6300esb'])
+        ret.extend(['-device', 'i6300esb'])
 
         if is_native and os.access('/dev/kvm', os.R_OK):
             # If we're likely to use KVM, request a full-featured CPU.


### PR DESCRIPTION
Newer qemu complains:

qemu-system-x86_64: -watchdog i6300esb: warning: -watchdog is deprecated; use -device instead.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>