### PR TITLE
2 Fixes:  for modules.order containing *.o's,  -watchdog

### DIFF
--- a/bin/virtme-prep-kdir-mods
+++ b/bin/virtme-prep-kdir-mods
@@ -24,7 +24,8 @@ ln -srfT . "$MODDIR/build"
 # Remove all preexisting symlinks and add symlinks to all modules that belong
 # to the build kenrnel.
 find "$MODDIR/kernel" -type l -print0 |xargs -0 rm -f --
-while read -r i; do
+while read -r in; do
+    i=${in/%\.o/.ko}
     [ ! -e "$i" ] && i=$(echo "$i" | sed s:^kernel/::)
     mkdir -p "$MODDIR/kernel/$(dirname "$i")"
     ln -sr "$i" "$MODDIR/kernel/$i"

--- a/virtme/architectures.py
+++ b/virtme/architectures.py
@@ -71,7 +71,7 @@ class Arch_x86(Arch):
         ret = Arch.qemuargs(is_native)
 
         # Add a watchdog.  This is useful for testing.
-        ret.extend(['-watchdog', 'i6300esb'])
+        ret.extend(['-device', 'i6300esb', '-watchdog-action', 'pause'])
 
         if is_native and os.access('/dev/kvm', os.R_OK):
             # If we're likely to use KVM, request a full-featured CPU.


### PR DESCRIPTION
1st fixes virtme-run  --kdir <dir>